### PR TITLE
Revert Stripe Android to 10.4.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   implementation 'com.android.support:appcompat-v7:28.0.0'
   implementation "com.google.android.gms:play-services-wallet:$googlePlayServicesVersion"
   implementation "com.google.firebase:firebase-core:$firebaseVersion"
-  implementation 'com.stripe:stripe-android:10.4.6'
+  implementation 'com.stripe:stripe-android:10.4.2'
   implementation 'com.github.tipsi:CreditCardEntry:1.5.1'
 }
 repositories {


### PR DESCRIPTION
Reverted stripe-android to 10.4.2, the closest stable version to the previously removed (from release history) 10.4.6